### PR TITLE
Add forward simulations

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ except for Cyclus, which the user must install themself.
 | [Aesara](https://aesara.readthedocs.io/en/latest/) | `2.8.2` | included in PyMC |
 | [Arviz](https://python.arviz.org/en/latest/index.html) | `0.12.1` | |
 | [NumPy](https://numpy.org/doc/stable/index.html) | `1.23.3` | |
+| [Scipy](https://docs.scipy.org/doc/scipy/index.html) | `1.9.1` | |
 | [Pandas](https://pandas.pydata.org/) | `1.5.0` | only for plotting |
 | [matplotlib](https://matplotlib.org/) | `3.6.0` | only for plotting |
 | [seaborn](https://seaborn.pydata.org/) | `0.12.0` | only for plotting |
@@ -60,11 +61,22 @@ You can still run the inference process, but features from
 `bicyclus/visualize` may not be available.
 
 ### Tutorial
+#### Inference mode
 A minimum working example (MWE) can be found in the [`examples`](/examples)
 directory.
 At the moment, Bicyclus can be used through a driver script that has to be
 written on a case-by-case basis.
 However, the MWE provided should be a good starting point for any new driver script.
+
+#### Forward mode
+Bicyclus can be used to perform large-scale forward simulations with Cyclus,
+which can be useful, e.g., to perform sensity analyses.
+This so-called forward mode uses Quasi Monte Carlo sampling (specifically, Sobol
+sequences) to efficiently sample the input parameter space.
+Furthermore, the driver script and file structure used in the inference mode can
+largely be reused here.
+
+An MWE might be provided at a later stage.
 
 ## Legacy code
 Originally, this work was developed as part of a Bachelor's thesis by Lewin

--- a/bicyclus/blackbox/__init__.py
+++ b/bicyclus/blackbox/__init__.py
@@ -1,3 +1,3 @@
-from .blackbox import CyclusCliModel
+from .blackbox import CyclusCliModel, CyclusForwardModel
 from .likelihood import (CyclusLogLikelihood, LikelihoodFunction,
     LogLikelihoodGrad)

--- a/bicyclus/blackbox/blackbox.py
+++ b/bicyclus/blackbox/blackbox.py
@@ -13,7 +13,8 @@ from scipy.stats.qmc import Sobol, discrepancy, scale
 
 from bicyclus.util import log
 
-class CyclusCliModel:
+
+class CyclusCliModel(ABC):
     """Base class that can mutate a model and run Cyclus simulations.
 
     This class doesn't use the occasionally brittle python module, but
@@ -25,13 +26,13 @@ class CyclusCliModel:
         self.last_sqlite_file = None
         self.result0 = None  # Groundtruth results for later comparison.
 
+    @abstractmethod
     def mutate(self, params=None):
         """Apply a mutation according to params.
 
         If params is None, a default model should be generated.
         """
-        self.mut_model = copy.deepcopy(self.model)
-        # override to do actual mutation!
+        pass
 
     def simulate(self, cyclus_args={}):
         tmpfile = tempfile.NamedTemporaryFile(delete=False,
@@ -71,9 +72,10 @@ class CyclusCliModel:
         # At this point, result() can extract the desired results from
         # last_sqlite_file.
 
+    @abstractmethod
     def result(self):
         """Extract results from self.last_sqlite_file here."""
-        return None
+        pass
 
     def run_groundtruth(self):
         self.simulate()

--- a/bicyclus/blackbox/blackbox.py
+++ b/bicyclus/blackbox/blackbox.py
@@ -3,9 +3,15 @@ import json
 import os
 import subprocess
 import tempfile
+from abc import ABC, abstractmethod
+from math import log10
+from pathlib import Path
 
-from ..util import log
+from numpy import savetxt
+from numpy.random import default_rng
+from scipy.stats.qmc import Sobol, discrepancy, scale
 
+from bicyclus.util import log
 
 class CyclusCliModel:
     """Base class that can mutate a model and run Cyclus simulations.
@@ -73,3 +79,167 @@ class CyclusCliModel:
         self.simulate()
         self.result0 = self.result()
         return self.result0
+
+class CyclusForwardModel(ABC):
+    """Class for measurement-independent sampling and uncertainty analysis.
+
+    The parameter file passed to this class uses the same structure as the
+    file used by `CyclusCliModel`. As the class uses Sobol sequences to
+    efficiently cover the complete input parameter space, the prior
+    distribution used must be 'Uniform'.
+    """
+    def __init__(self, input_params_fname, n_samples_exponent, seed,
+                 data_output_dir=".", log_output_dir=".",
+                 output_fnames="bicyclus_forward"):
+        """Initialise class.
+
+        Parameters
+        ----------
+        input_params_fname : str
+            Filename where input parameters and parameter ranges are stored.
+            Must be a .json file.
+
+        n_samples_exponent : int
+            Logarithm in base 2 of the number of samples, i.e., number of
+            samples = 2^n_samples_exponent.
+
+        seed : int
+            Seed used to create the Sobol sequences.
+
+        data_output_dir : str or path, optional
+            Directory where Cyclus output files are stored. Default is current
+            directory.
+
+        log_output_dir : str or path, optional
+            Directory where parameter samples and log are stored. Default is
+            current directory.
+
+        output_fnames : str, optional
+            Basename of all output files, i.e., file with drawn parameters,
+            log, and Cyclus .sqlite files.
+        """
+        self.rng = default_rng(seed=seed)
+        log.log_print(f"Using RNG {self.rng} with seed {seed}")
+
+        self.input_params_fname = input_params_fname
+        self.data_output_dir = Path(data_output_dir).absolute()
+        self.log_output_dir = Path(log_output_dir).absolute()
+        self.output_fnames = output_fnames
+
+        self.n_samples_exponent = n_samples_exponent
+        self.parameter_names, self.samples = self.generate_samples()
+
+    def generate_samples(self):
+        """Create samples using Sobol sequences, a QMC method."""
+        with open(self.input_params_fname, "r") as f:
+            parameters = json.load(f)
+        parameter_names = list(parameters.keys())
+        log.log_print("Generating samples for the following "
+                      f"{len(parameter_names)} parameters: "
+                      f"{', '.join(parameter_names)}")
+
+        sobol_sampler = Sobol(d=len(parameter_names), seed=self.rng)
+        lower_bounds = []
+        upper_bounds = []
+        for param in parameters.values():
+            if param["type"] != "Uniform":
+                msg = ("At the moment, parameter distributions must be Uniform"
+                       " distributions.")
+                raise ValueError(msg)
+            lower_bounds.append(param["lower"])
+            upper_bounds.append(param["upper"])
+
+        samples = scale(
+            sobol_sampler.random_base2(self.n_samples_exponent),
+            lower_bounds, upper_bounds)
+        discrepancy_ = discrepancy(samples)
+        log.log_print(f"Generated {samples.shape[0]} samples for "
+                      f"{samples.shape[1]} parameters with discrepancy "
+                      f"{discrepancy_}.")
+        output_fname = (self.log_output_dir
+                        / f"parameters_{self.output_fnames}.csv")
+        savetxt(output_fname, samples, header=" ".join(parameter_names))
+        log.log_print("Stored samples in:", output_fname)
+
+        return parameter_names, samples
+
+    @abstractmethod
+    def generate_input_file(self, sample):
+        """Generate a Cyclus input file using the form described below.
+
+        Parameters
+        ----------
+        sample : dict
+            Dict with keys being the parameter names (as defined in the input
+            parameter file) and values being the drawn parameter samples.
+
+        Returns
+        -------
+        dict
+            A dict containing the Cyclus input file. This will be converted
+            and stored as a .json file.
+        """
+        pass
+
+    def run_simulations(self, cyclus_args={}, const_sim_params={}):
+        """Run Cyclus simulations using generated set of parameters.
+
+        Parameters
+        ----------
+        cyclus_args : dict, optional
+            Commandline args passed to Cyclus.
+
+        const_sim_parms : dict, optional
+            Parameters that are not sampled but should be passed to the input
+            file generator in addition to the sampled parameters.
+        """
+        n_samples = 2**self.n_samples_exponent
+        width_samples = int(log10(2**self.n_samples_exponent)) + 1
+
+        log.log_print("Starting simulations. Storing Cyclus output files in:"
+                      f"{self.data_output_dir}")
+
+        for i, sample in enumerate(self.samples):
+            log.log_print("Generating input file.")
+            parameters = {k: v for k, v in zip(self.parameter_names, sample)}
+            if not const_sim_params.keys().isdisjoint(parameters.keys()):
+                intersection = const_sim_params.keys() & parameters.keys()
+                msg = ("Sampled parameters and constant parameters must "
+                       f"differ. Common parameters: {intersection}")
+                raise RuntimeError(msg)
+
+            parameters.update(const_sim_params)
+            input_file = self.generate_input_file(parameters)
+
+            tmpfile = tempfile.NamedTemporaryFile(delete=False, mode="w",
+                                                  suffix=".json")
+            json.dump(input_file, tmpfile)
+            tmpfile.flush()
+            tmpfile.close()
+
+            outfile = (
+                self.data_output_dir /
+                f"cyclus_{self.output_fnames}_{i}.sqlite"
+            )
+
+            # Existing files are deleted, else Cyclus would append results.
+            if os.path.isfile(outfile):
+                os.unlink(outfile)
+
+            cyclus_argv = ['cyclus', "-i", tmpfile.name, "-o", outfile]
+            cyclus_argv.extend([j for i in cyclus_args.items() for j in i])
+            log.log_print("Running Cyclus:", cyclus_argv)
+
+            run = subprocess.run(cyclus_argv, shell=False, timeout=300,
+                                 stdout=subprocess.PIPE,
+                                 stderr=subprocess.PIPE)
+            if run.returncode != 0:
+                log.log_print("Error running cyclus. stdout/stderr:",
+                              run.stdout, run.stderr)
+                raise RuntimeError("Cyclus returned error")
+
+            log.log_print(
+                f"Simulation finished. {i + 1:>{width_samples}} / {n_samples}")
+            os.unlink(tmpfile.name)
+
+        log.log_print(f"Finished sampling of {n_samples} samples.")

--- a/bicyclus/util/__init__.py
+++ b/bicyclus/util/__init__.py
@@ -1,5 +1,6 @@
 from .log import (log_file_path, log_init_debug_info, log_print,
     task_identifier, write_to_log_file)
-from .parsers import SamplingParser, CyclusRunParser
+from .parsers import (CyclusRunParser, ForwardSimulationParser,
+    ReconstructionParser, SamplingParser)
 from .postprocessing import extract_from_log, extract_single_log
 from .util import generate_start_values, sampling_parameter_to_pymc, save_trace

--- a/bicyclus/util/util.py
+++ b/bicyclus/util/util.py
@@ -139,13 +139,16 @@ def save_trace(args, trace, i=0):
         /bicyclus/util/parsers.py. This functioning may be adapted later to
         become independent of the Bicyclus-argparser.
 
-    trace : pymc3 MultiTrace object
-        The trace to be saved.
+    trace : pm.MultiTrace or az.InferenceData
+        The trace or InferenceData to be saved.
 
     i : int, optional
         Index
     """
-    inference_data = pm.to_inference_data(trace)
+    if isinstance(trace, pm.backends.base.MultiTrace):
+        inference_data = pm.to_inference_data(trace)
+    else:
+        inference_data = trace
     output_path = samples_output_path(i, args.run, dir_=args.output_path)
 
     log_print(f"Saving trace #{i} ({trace}) to file {output_path}")

--- a/examples/run.py
+++ b/examples/run.py
@@ -284,7 +284,7 @@ def sample(args, pymc_model, initvals=None):
 
 def main():
     """Main entry point of the script."""
-    parser = bicyclus.util.SamplingParser()
+    parser = bicyclus.util.ReconstructionParser()
     args = parser.get_args()
 
     bicyclus.util.write_to_log_file(run=args.run, outpath=args.log_path,

--- a/examples/run.py
+++ b/examples/run.py
@@ -228,7 +228,6 @@ def sample(args, pymc_model, initvals=None):
                         f"sampling iteration {i} at {args.samples} samples "
                         f"per iteration using {args.algorithm}, "
                         f"initial parameters {initvals}")
-                # Refer to https://discourse.pymc.io/t/blackbox-likelihood-example-doesnt-work/5378
                 trace = pm.sample(
                     draws=args.samples,
                     tune=args.tune,
@@ -236,7 +235,6 @@ def sample(args, pymc_model, initvals=None):
                     chains=args.chains,
                     cores=args.cores,
                     initvals=initvals,
-                    return_inferencedata=False,
                     compute_convergence_checks=False,
                     progressbar=False,
                     random_seed=RNG,

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = bicyclus
-version = 0.1.0
+version = 0.2.0
 description = Code for running Bayesian Inference on Cyclus nuclear fuel cycle simulations
 long_description = file: README.md
 author = Lewin Bormann, Max Schalz

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ install_requires =
   arviz
   numpy
   pymc
+  scipy
 
 [options.extras_require]
 plotting =


### PR DESCRIPTION
Second attempt, see #18 . Forward stuff has been tested in some runs and everything worked fine.

## Changes
- Add forward simulator which uses Sobol sequences to cover the input parameter space in a low-discrepancy manner.
- Update `bicyclus.util.save_trace` to accept both `arviz.InferenceData` and `pymc.MultiTrace`.
